### PR TITLE
Fix bug where q is missing in request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fountainhead-bitsocketd",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The message bus for bitcoin",
   "main": "index.js",
   "scripts": {

--- a/socket.js
+++ b/socket.js
@@ -58,6 +58,9 @@ const init = function(config) {
       res.sseSetup()
       let json = Buffer.from(b64, "base64").toString()
       let query = JSON.parse(json)
+      if (! query.q) {
+          query.q = {};
+      }
 
       res.$fingerprint = fingerprint
       connections.pool[fingerprint] = { res: res, query: query }


### PR DESCRIPTION
Otherwise with a request like `{}` there will be issue inside bit.js promise / .db undefined. 